### PR TITLE
Rename scripts as omero-scripts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,6 @@
 [submodule "omero-dropbox"]
 	path = omero-dropbox
 	url = git://github.com/ome/omero-dropbox
-[submodule "scripts"]
-	path = scripts
-	url = git://github.com/ome/scripts
+[submodule "omero-scripts"]
+	path = omero-scripts
+	url = git://github.com/ome/omero-scripts

--- a/repositories.yml
+++ b/repositories.yml
@@ -1,5 +1,5 @@
 base-branch: master
 
 submodules:
-  scripts:
+  omero-scripts:
     base-branch: develop


### PR DESCRIPTION
This matches the renaming of the repository from `scripts` to `omero-scripts` (for PyPI release) and allows the current devspace logic to work similarly to other OMERO Python components.