### PR TITLE
Drop 'python setup.py sdist' for 'python -m build'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
                     # VERSION will be in omero-py/setup.py
                     export ZIP_FILE=${env.WORKSPACE}/omero-blitz-VERSION-python.zip
                     git submodule update --init --recursive
-                    git submodule foreach python3 setup.py sdist
+                    git submodule foreach python3 -m build
                 """
                 archiveArtifacts artifacts: '*/dist/*tar.gz'
             }


### PR DESCRIPTION
The use of `python setup.py` is now *strongly* discouraged by the [PYPA](https://www.pypa.io/). `python -m build` runs sdist as well as builds the wheel.

Note: this will likely require pip installing `build` within the
      containers of devspace.